### PR TITLE
Add SingleStepTests runner, fix undoc behavior and cycles for CHK/DIV*/LINK, optimize DIV*/MUL*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cyclone.s
 cscope.out
 tags
 tests/test_misc2.bin
+tests/SingleStepTests/tester

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/SingleStepTests/m68000"]
+	path = tests/SingleStepTests/m68000
+	url = https://github.com/SingleStepTests/m68000.git

--- a/Ea.cpp
+++ b/Ea.cpp
@@ -381,6 +381,10 @@ int EaRead(int a,int v,int ea,int size,int mask,EaRWType type,int set_nz)
       flags_set=1;
     }
   }
+  else if (type == earwt_zero_extend)
+  {
+    ZeroExtend(v, 0, size);
+  }
   else
   {
     if (type == earwt_shifted_up && shift) {

--- a/Ea.cpp
+++ b/Ea.cpp
@@ -144,6 +144,15 @@ int EaCalc(int a,int mask,int ea,int size,EaRWType type)
 
   DisaPc=2; DisaGetEa(text,ea,size); // Get text version of the effective address
 
+  if (a==10 && flags_in_reg)
+  {
+#if MEMHANDLERS_NEED_FLAGS
+    ot("  mov r10,r10,lsr #28\n");
+    ot("  strb r10,[r7,#0x46] ;@ Save Flags (NZCV)\n");
+#endif
+    flags_in_reg=0;
+  }
+
   if (ea<0x10)
   {
     // Saves one opcode as we can shift in ldr/str
@@ -308,6 +317,15 @@ int EaRead(int a,int v,int ea,int size,int mask,EaRWType type,int set_nz)
   const char *s="";
   int flags_set=0;
   int shift=0;
+
+  if (v==10 && flags_in_reg)
+  {
+#if MEMHANDLERS_NEED_FLAGS
+    ot("  mov r10,r10,lsr #28\n");
+    ot("  strb r10,[r7,#0x46] ;@ Save Flags (NZCV)\n");
+#endif
+    flags_in_reg=0;
+  }
 
   if (set_nz) {
     if (type == earwt_msb_dont_care || type == earwt_zero_extend) {

--- a/Main.cpp
+++ b/Main.cpp
@@ -237,7 +237,7 @@ static void PrintFramework()
   ot("  add r0,r12,#0xe000*4 ;@ ctrl code pointer\n");
   ot("  ldr r1,[r0,#-4]\n");
   ot("  tst r1,r1\n");
-  ot("  movne pc,lr ;@ already uncompressed\n");
+  ot("  bxne lr ;@ already uncompressed\n");
   ot("  stmfd sp!,{r7,lr}\n");
   ot("  mov r7,r12 ;@ jump table\n");
   ot("  add r3,r12,#0xa000*4 ;@ handler table pointer, r12=dest\n");
@@ -1044,7 +1044,7 @@ static void PrintOpcodes()
   ot("  tst r11,r11\n");
   ot("  moveq r0,#0\n");
   ot("  movne lr,pc\n");
-  ot("  movne pc,r11 ;@ call UnrecognizedCallback if it is defined\n");
+  ot("  bxne r11 ;@ call UnrecognizedCallback if it is defined\n");
   ot("  ldrb r10,[r7,#0x46] ;@ r10 = Load Flags (NZCV)\n");
   ot("  ldr r5,[r7,#0x5c] ;@ Load Cycles\n");
   ot("  ldr r4,[r7,#0x40] ;@ Load PC\n");
@@ -1074,7 +1074,7 @@ static void PrintOpcodes()
   ot("  tst r11,r11\n");
   ot("  moveq r0,#0\n");
   ot("  movne lr,pc\n");
-  ot("  movne pc,r11 ;@ call UnrecognizedCallback if it is defined\n");
+  ot("  bxne r11 ;@ call UnrecognizedCallback if it is defined\n");
   ot("  ldrb r10,[r7,#0x46] ;@ r10 = Load Flags (NZCV)\n");
   ot("  ldr r5,[r7,#0x5c] ;@ Load Cycles\n");
   ot("  ldr r4,[r7,#0x40] ;@ Load PC\n");
@@ -1103,7 +1103,7 @@ static void PrintOpcodes()
   ot("  tst r11,r11\n");
   ot("  moveq r0,#0\n");
   ot("  movne lr,pc\n");
-  ot("  movne pc,r11 ;@ call UnrecognizedCallback if it is defined\n");
+  ot("  bxne r11 ;@ call UnrecognizedCallback if it is defined\n");
   ot("  ldrb r10,[r7,#0x46] ;@ r10 = Load Flags (NZCV)\n");
   ot("  ldr r5,[r7,#0x5c] ;@ Load Cycles\n");
   ot("  ldr r4,[r7,#0x40] ;@ Load PC\n");

--- a/Main.cpp
+++ b/Main.cpp
@@ -514,7 +514,7 @@ static void PrintFramework()
   ot("  movle r0,#0\n");
   ot("  bxle lr ;@ no ints\n");
   ot("\n");
-  ot("  stmdb sp!,{r4,r5,r7,r8,r10,r11,lr}\n");
+  ot("  stmdb sp!,{r4-r8,r10,r11,lr}\n");
   ot("  mov r7,r0\n");
   ot("  mov r0,r2\n");
   ot("  ldrb r10,[r7,#0x46]  ;@ r10 = Flags (NZCV)\n");
@@ -529,7 +529,7 @@ static void PrintFramework()
   ot("  rsb r0,r5,#0\n");
   ot("  str r4,[r7,#0x40]   ;@ Save Current PC + Memory Base\n");
   ot("  strb r10,[r7,#0x46] ;@ Save Flags (NZCV)\n");
-  ot("  ldmia sp!,{r4,r5,r7,r8,r10,r11,lr}\n");
+  ot("  ldmia sp!,{r4-r8,r10,r11,lr}\n");
   ot("  bx lr\n");
   ot("\n");
   ot("\n");

--- a/Main.cpp
+++ b/Main.cpp
@@ -1262,11 +1262,28 @@ static void PrintJumpTable()
 #endif
 }
 
+static void DeclareGlobalFunc(const char *name)
+{
+  if (ms) ot("  export %s [FUNC]\n",name);
+  else {
+    ot("  .global %s\n",name);
+    ot("  .type %s,%%function\n",name);
+  }
+}
+
+static void DeclareGlobalData(const char *name)
+{
+  if (ms) ot("  export %s [DATA]\n",name);
+  else {
+    ot("  .global %s\n",name);
+    ot("  .type %s,%%object\n",name);
+  }
+}
+
 static int CycloneMake()
 {
   int i;
   const char *name="Cyclone.s";
-  const char *globl=ms?"export":".global";
 
   // Open the assembly file
   if (ms) name="Cyclone.asm";
@@ -1289,24 +1306,24 @@ static int CycloneMake()
   for(i=0xf000; i<0x10000; i++) CyJump[i] = -3; // f-line emulation
 
   ot(ms?"  area |.text|, code\n":"  .text\n  .align 4\n\n");
-  ot("  %s CycloneInitJT\n",globl);
-  ot("  %s CycloneResetJT\n",globl);
-  ot("  %s CycloneRun\n",globl);
-  ot("  %s CycloneSetSr\n",globl);
-  ot("  %s CycloneGetSr\n",globl);
-  ot("  %s CycloneFlushIrq\n",globl);
-  ot("  %s CyclonePack\n",globl);
-  ot("  %s CycloneUnpack\n",globl);
-  ot("  %s CycloneVer\n",globl);
-  ot("  %s CycloneJumpTab\n",globl);
+  DeclareGlobalFunc("CycloneInitJT");
+  DeclareGlobalFunc("CycloneResetJT");
+  DeclareGlobalFunc("CycloneRun");
+  DeclareGlobalFunc("CycloneSetSr");
+  DeclareGlobalFunc("CycloneGetSr");
+  DeclareGlobalFunc("CycloneFlushIrq");
+  DeclareGlobalFunc("CyclonePack");
+  DeclareGlobalFunc("CycloneUnpack");
+  DeclareGlobalData("CycloneVer");
+  DeclareGlobalData("CycloneJumpTab");
 #if (CYCLONE_FOR_GENESIS == 2)
-  ot("  %s CycloneSetRealTAS_JT\n",globl);
-  ot("  %s CycloneDoInterrupt\n",globl);
-  ot("  %s CycloneDoTrace\n",globl);
-  ot("  %s Op____\n",globl);
-  ot("  %s Op6002\n",globl);
-  ot("  %s Op6602\n",globl);
-  ot("  %s Op6702\n",globl);
+  DeclareGlobalFunc("CycloneSetRealTAS_JT");
+  DeclareGlobalFunc("CycloneDoInterrupt");
+  DeclareGlobalFunc("CycloneDoTrace");
+  DeclareGlobalFunc("Op____");
+  DeclareGlobalFunc("Op6002");
+  DeclareGlobalFunc("Op6602");
+  DeclareGlobalFunc("Op6702");
 #endif
   ot("\n");
   ot(ms?"CycloneVer dcd 0x":"CycloneVer: .long 0x");

--- a/Main.cpp
+++ b/Main.cpp
@@ -21,6 +21,8 @@ const char * const Narm[4]={ "b", "h","",""}; // Normal ARM Extensions for opera
 const char * const Sarm[4]={"sb","sh","",""}; // Sign-extend ARM Extensions for operand sizes 0,1,2
 int Cycles; // Current cycles for opcode
 int pc_dirty; // something changed PC during processing
+int pc_in_reg; // PC is currently held in r4
+int flags_in_reg; // flags are currently held in r10
 int arm_op_count;
 
 // opcodes often used by games
@@ -143,6 +145,8 @@ static void AddressErrorWrapper(char rw, const char *dataprg, int iw)
 
 void FlushPC(int force)
 {
+  if (force)
+    pc_in_reg = 0;
 #if MEMHANDLERS_NEED_PC
   force |= pc_dirty;
   pc_dirty = 0;
@@ -289,6 +293,7 @@ static void PrintFramework()
   ot("\n");
 
   // --------------
+  pc_dirty=0; pc_in_reg=0; flags_in_reg=0; // prevent memhandlers from trashing regs
   ot("CycloneResetJT%s\n", ms?"":":");
   ot("  stmfd sp!,{r7,lr}\n");
   ot("  mov r7,r0\n");
@@ -505,6 +510,7 @@ static void PrintFramework()
   ot("\n");
 
   // --------------
+  pc_in_reg=1; flags_in_reg=1; // allow memhandlers to save/restore pc/flag regs
   ot("CycloneFlushIrq%s\n", ms?"":":");
   ot("  ldr r1,[r0,#0x44]  ;@ Get SR high T_S__III and irq level\n");
   ot("  mov r2,r1,lsr #24 ;@ Get IRQ level\n"); // same as  ldrb r0,[r7,#0x47]
@@ -568,6 +574,9 @@ static void PrintFramework()
   ot(";@ Push old PC onto stack\n");
   ot("  sub r0,r11,#4 ;@ Predecremented A7\n");
   ot("  sub r1,r4,r1 ;@ r1 = Old PC\n");
+#if MEMHANDLERS_NEED_PC
+  FlushPC(1); // prevent repeated restores
+#endif
   MemHandler(1,2);
   ot(";@ Push old SR:\n");
   ot("  ldr r0,[r7,#0x4c]   ;@ X bit\n");
@@ -589,7 +598,9 @@ static void PrintFramework()
 #if USE_INT_ACK_CALLBACK
   ot(";@ call IrqCallback if it is defined\n");
 #if INT_ACK_NEEDS_STUFF
+ #if !MEMHANDLERS_NEED_PC // already saved
   ot("  str r4,[r7,#0x40] ;@ Save PC\n");
+ #endif
   ot("  mov r1,r10,lsr #28\n");
   ot("  strb r1,[r7,#0x46] ;@ Save Flags (NZCV)\n");
   ot("  str r5,[r7,#0x5c] ;@ Save Cycles\n");
@@ -691,6 +702,9 @@ static void PrintFramework()
   ot("  sub r0,r0,#4 ;@ Predecremented A7\n");
   ot("  str r0,[r7,#0x3c] ;@ Save A7\n");
   ot("  sub r1,r4,r1 ;@ r1 = Old PC\n");
+#if MEMHANDLERS_NEED_PC
+  FlushPC(1); // prevent repeated restores
+#endif
   MemHandler(1,2);
   ot(";@ Push old SR:\n");
   ot("  ldr r0,[r7,#0x4c]   ;@ X bit\n");
@@ -801,6 +815,9 @@ static void PrintFramework()
   ot("  sub r0,r0,#4 ;@ Predecremented A7\n");
   ot("  sub r1,r4,r1 ;@ r1 = Old PC\n");
   ot("  str r0,[r7,#0x3c] ;@ Save A7\n");
+#if MEMHANDLERS_NEED_PC
+  FlushPC(1); // prevent repeated restores
+#endif
   MemHandler(1,2,0,EMULATE_HALT);
   // SR
   ot(";@ Push old SR:\n");
@@ -946,8 +963,10 @@ int MemHandler(int type,int size,int addrreg,int need_addrerr_check)
   char what[32];
 
 #if MEMHANDLERS_NEED_FLAGS
-  ot("  mov r3,r10,lsr #28\n");
-  ot("  strb r3,[r7,#0x46] ;@ Save Flags (NZCV)\n");
+  if (flags_in_reg) {
+    ot("  mov r3,r10,lsr #28\n");
+    ot("  strb r3,[r7,#0x46] ;@ Save Flags (NZCV)\n");
+  }
 #endif
   FlushPC();
 
@@ -1007,11 +1026,14 @@ int MemHandler(int type,int size,int addrreg,int need_addrerr_check)
   ot(" handler\n");
 
 #if MEMHANDLERS_CHANGE_FLAGS
-  ot("  ldrb r10,[r7,#0x46] ;@ r10 = Load Flags (NZCV)\n");
-  ot("  mov r10,r10,lsl #28\n");
+  if (flags_in_reg) {
+    ot("  ldrb r10,[r7,#0x46] ;@ r10 = Load Flags (NZCV)\n");
+    ot("  mov r10,r10,lsl #28\n");
+  }
 #endif
 #if MEMHANDLERS_CHANGE_PC
-  ot("  ldr r4,[r7,#0x40] ;@ Load PC\n");
+  if (pc_in_reg)
+    ot("  ldr r4,[r7,#0x40] ;@ Load PC\n");
 #endif
 
   return 0;

--- a/Main.cpp
+++ b/Main.cpp
@@ -968,6 +968,8 @@ int MemHandler(int type,int size,int addrreg,int need_addrerr_check)
   addrreg=0;
 #endif
 
+  sprintf(what, "%s%d", type==0 ? "read" : (type==1 ? "write" : "fetch"), 8<<size);
+
 #if EMULATE_ADDRESS_ERRORS_IO
   if (size > 0 && need_addrerr_check)
   {
@@ -983,7 +985,6 @@ int MemHandler(int type,int size,int addrreg,int need_addrerr_check)
   else
 #endif
 
-  sprintf(what, "%s%d", type==0 ? "read" : (type==1 ? "write" : "fetch"), 8<<size);
 #ifdef MEMHANDLERS_DIRECT_PREFIX
   if (addrreg != 0)
     ot("  mov r0,r%i\n", addrreg);

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ CFLAGS += -Wall -ggdb
 ifdef CONFIG_FILE
 CFLAGS += -DCONFIG_FILE="\"$(CONFIG_FILE)\""
 endif
+ifdef HAVE_ARMv5
+CFLAGS += -DHAVE_ARMv5=$(HAVE_ARMv5)
+endif
 ifdef HAVE_ARMv6
 CFLAGS += -DHAVE_ARMv6=$(HAVE_ARMv6)
 endif

--- a/OpAny.cpp
+++ b/OpAny.cpp
@@ -174,7 +174,7 @@ void SignExtend(int rd, int rs, int size)
       ot("  mov r%d,r%d\n", rd, rs);
     return;
   }
-#if defined(HAVE_ARMv6) && (HAVE_ARMv6)
+#if HAVE_ARMv6
   if (size == 1)
     ot("  sxth r%d,r%d ;@ sign extend\n", rd, rs);
   else
@@ -194,7 +194,7 @@ void ZeroExtend(int rd, int rs, int size)
       ot("  mov r%d,r%d\n", rd, rs);
     return;
   }
-#if defined(HAVE_ARMv6) && (HAVE_ARMv6)
+#if HAVE_ARMv6
   if (size == 1)
     ot("  uxth r%d,r%d ;@ zero extend\n", rd, rs);
   else

--- a/OpAny.cpp
+++ b/OpAny.cpp
@@ -75,6 +75,8 @@ void OpStart(int op, int sea, int tea, int op_changes_cycles, int supervisor_che
   if (last_op_count!=arm_op_count)
     ot("\n");
   pc_dirty = 1;
+  pc_in_reg = 1;
+  flags_in_reg = 1;
   opend_op_changes_cycles = opend_check_interrupt = opend_check_trace = 0;
 }
 
@@ -156,6 +158,7 @@ int OpGetFlags(int subtract,int xbit,int specialz)
   {
     ot("  str r10,[r7,#0x4c] ;@ Save X bit\n");
   }
+  flags_in_reg=1;
   return 0;
 }
 
@@ -163,6 +166,7 @@ void OpGetFlagsNZ(int rd)
 {
   ot("  and r10,r%d,#0x80000000 ;@ r10=N_flag\n",rd);
   ot("  orreq r10,r10,#0x40000000 ;@ get NZ, clear CV\n");
+  flags_in_reg=1;
 }
 
 // size 0=8bit, 1=16bit

--- a/OpArith.cpp
+++ b/OpArith.cpp
@@ -353,31 +353,25 @@ int OpMul(int op)
   if (type==1)
   {
     ot(";@ Calculate cycles needed: 2*(#bits set in multiplier engine mask)\n");
-    if (sign) {
-            ot("  eor r0,r1,r1,asr #1\n");
-            ot("  tst r0,#0x8000 ;@ handle 17th bit\n");
-            ot("  subne r5,r5,#2\n");
-    } else  ot("  mov r0,r1\n");
-    ot("  mov r3,#0x55000000 ;@ count top 16 bits, the O(1) way\n");
-    ot("  orr r3,r3,r3,lsr #8\n");
-    ot("  and r3,r3,r0,lsr #1\n");
-    ot("  sub r0,r0,r3\n");
-    ot("  mov r3,#0x33000000\n");
-    ot("  orr r3,r3,r3,lsr #8\n");
-    ot("  and r12,r3,r0,lsr #2\n");
-    ot("  and r0,r3,r0\n");
-    ot("  add r0,r0,r12\n");
-    ot("  mov r3,#0x0f000000\n");
-    ot("  orr r3,r3,r3,lsr #8\n");
+    if (sign) ot("  eor r0,r1,r1,lsl #1\n");
+    ot("  mov r12,#0x0F000000 ;@ count top 16 bits, the O(1) way\n");
+    ot("  orr r12,r12,r12,lsr #8 ;@ r12 = 0x0F0F0000\n");
+    ot("  eor r10,r12,r12,lsl #2 ;@ r10 = 0x33330000\n");
+    ot("  eor r3,r10,r10,lsl #1  ;@ r3  = 0x55550000\n");
+    ot("  and r3,r3,r%d,lsr #1\n",sign?0:1);
+    ot("  sub r0,r%d,r3\n",sign?0:1);
+    ot("  and r3,r10,r0,lsr #2\n");
+    ot("  and r0,r10,r0\n");
+    ot("  add r0,r0,r3\n");
     ot("  add r0,r0,r0,lsr #4\n");
-    ot("  and r0,r3,r0\n");
+    ot("  and r0,r12,r0\n");
     ot("  add r0,r0,r0,lsl #8\n");
     ot("  sub r5,r5,r0,lsr #23 ;@ cycles -= 2*bitcount(mask)\n");
 
     ot(";@ Get 16-bit signs right:\n");
     ot("  mov r0,r1,%s #16\n",sign?"asr":"lsr");
-    ot("  mov r2,r2,lsl #16\n");
-    ot("  mov r2,r2,%s #16\n",sign?"asr":"lsr");
+    if (sign) SignExtend(2,2,1);
+    else      ZeroExtend(2,2,1);
     ot("\n");
 
     ot("  muls r2,r0,r2\n");

--- a/OpArith.cpp
+++ b/OpArith.cpp
@@ -216,6 +216,57 @@ int OpArithReg(int op)
 }
 
 // --------------------- Opcodes 0x80c0+ ---------------------
+static void UnrolledDiv()
+{
+  ot("  rsbs r0,r1,#0 ;@ negate divisor and clear carry\n");
+  ot("  sbc r10,r1,r1,lsr #1 ;@ r10=(divisor<<15)-1\n");
+  ot(";@ calculate number of skipped initial iterations\n");
+#if HAVE_ARMv5
+  // Use the difference in approximated log2 to determine skipped iterations,
+  // but round down by subtracting an extra 1.
+  // This rounded result may be less than 0, which is handled below.
+  ot("  orr r3,r2,r1,lsr #16 ;@ make sure the rounded difference is at most 15\n");
+  ot("  clz r3,r3 ;@ leading zeros of dividend, clamped to clz(divisor)+16\n");
+  ot("  clz r1,r1 ;@ leading zeros of divisor\n");
+  ot("  sbcs r3,r3,r1 ;@ subtract and round down (carry is still clear)\n");
+  ot("  mov r3,r3,lsl #1 ;@ each skipped iteration has 2 penalty cycle pairs\n");
+  ot(";@ add branch offset (12 bytes per iteration)\n");
+  ot("  add r1,r3,r3,lsl #1\n");
+  ot("  addhi pc,pc,r1,lsl #1 ;@ fallthrough if max iterations\n");
+  ot("  mov r3,#0 ;@ saturate negative cycles to 0\n");
+#else
+  ot("  mov r3,#0 ;@ number of additional cycle pairs\n");
+  // Resolve only to an even number of skipped iterations, because
+  // determining bit 0 would be just as expensive as the skipped iteration
+  for (int shift=8; shift!=1; shift>>=1)
+  {
+    ot("  cmp r2,r1,lsr #%d+1\n",shift);
+    ot("  addlo r3,r3,#%d*2 ;@ each skipped iteration has 2 penalty cycle pairs\n",shift);
+    if (shift!=2) ot("  movlo r1,r1,lsr #%d\n",shift);
+  }
+  ot("\n");
+  ot(";@ add branch offset (12 bytes per iteration)\n");
+  ot("  adds r1,r3,r3,lsl #1\n");
+  ot("  addne pc,pc,r1,lsl #1 ;@ fallthrough if max iterations\n");
+  ot("  nop ;@ padding for pc-relative offset\n");
+#endif
+  ot("\n");
+  ot(";@ For each iteration:\n");
+  ot(";@ Shift remainder into upper bits and compare the pre-shifted divisor to it.\n");
+  ot(";@ This resets carry if non-restoring, and sets overflow if remainder MSB was 1.\n");
+  ot(";@ Then, conditionally shift and add the negated divisor, setting an upper quotient bit.\n");
+  ot(";@ Finally, add 0, 1, or 2 penalty cycle pairs based on the overflow and carry flags.\n");
+  for (int shift=0; shift<16; shift++)
+  {
+    ot("  cmp r10,r2,lsl #%d\n",shift);
+    ot("  addcc r2,r2,r0,lsr #%d+1\n",shift);
+    // Final iteration has a fixed cycle length
+    if (shift!=15) ot("  adcvc r3,r3,#1\n");
+  }
+  ot("\n");
+  ot("  sub r5,r5,r3,lsl #1 ;@ Count penalty cycle pairs\n");
+}
+
 int OpMul(int op)
 {
   // Div/Mul: 1m00nnns 11eeeeee (m=Mul, nnn=Register Dn, s=signed, eeeeee=EA)
@@ -233,6 +284,24 @@ int OpMul(int op)
   use=OpBase(op,1);
   use&=~0x0e00; // Use same for all registers
   if (op!=use) { OpUse(op,use); return 0; } // Use existing handler
+
+  // Output common unrolled divide loop function before first DIVU opcode
+  if (op == 0x80c0)
+  {
+#if !INLINE_UNROLLED_DIV
+    ot(";@ ---------- Common unrolled division subroutine ----------\n");
+    ot(";@ Fully unrolled unsigned division, with accurate cycle counting.\n");
+    ot(";@ Assumes divide-by-zero and unsigned overflow checks have passed.\n");
+    ot(";@ Inputs: r2=dividend, r1=divisor<<16\n");
+    ot(";@ Output: r2=(quotient<<16)|remainder\n");
+    ot(";@ Destroys: r0,r1,r3,r10\n");
+    ot(";@ r5 is adjusted with the per-iteration penalty cycles.\n");
+    ot("DivideCommon%s\n",ms?"":":");
+    UnrolledDiv();
+    ot("  bx lr\n");
+    ot("\n");
+#endif
+  }
 
   OpStart(op,ea,0,1);
   if(type) Cycles=38;
@@ -258,46 +327,31 @@ int OpMul(int op)
       ot("  submi r5,r5,#2\n");
       ot("  rsbmi r2,r2,#0 ;@ Make r2 positive\n");
       ot("\n");
-      ot("  movs r0,r1,asr #16\n");
+      ot("  tst r1,r1\n");
       ot("  orrmi r12,r12,#0x40000000\n");
-      ot("  rsbmi r0,r0,#0 ;@ Make r0 positive\n");
-      ot("\n");
-      ot(";@ detect the nasty 0x80000000 / -1 situation\n");
-      ot("  subs r3,r2,#0x80000000\n");
-      ot("  addeqs r3,r1,#0x00010000\n");
-      ot("  beq wrendofop%.4x\n",op);
-      ot("\n");
+      ot("  rsbmi r1,r1,#0 ;@ Make r1 positive\n");
+    }
+    ot("\n");
 
-      ot(";@ Overflow?\n");
-      ot("  cmp r0,r2,lsr #16\n");
-      ot("  movls r10,#0x90000000 ;@ set overflow/negative flags\n");
-      ot("  bls endofop%.4x ;@ overflow!\n",op);
-      ot("\n");
+    ot(";@ Overflow?\n");
+    ot("  cmp r2,r1\n");
+    ot("  movhs r10,#0x90000000 ;@ set overflow/negative flags\n");
+    ot("  bhs endofop%.4x ;@ overflow!\n",op);
+    ot("\n");
 
-      ot(";@ Divide r2 by r0\n");
-      ot("  mov r3,#0\n");
-      ot("  mov r1,r0\n");
-      ot("\n");
-      ot(";@ Shift up divisor till it's just less than numerator\n");
-      ot("Shift%.4x%s\n",op,ms?"":":");
-      ot("  cmp r1,r2,lsr #1\n");
-      ot("  movls r1,r1,lsl #1\n");
-      ot("  bcc Shift%.4x\n",op);
-      ot("\n");
+    ot("  sub r5,r5,#%d ;@ Minimum cycles divide loop can take\n",sign?74:66);
+#if INLINE_UNROLLED_DIV
+    UnrolledDiv();
+#else
+    ot("  bl DivideCommon ;@ Divide r2 by (r1>>16)\n");
+#endif
+    ot(";@r2==(quotient<<16)|remainder\n");
+    ot("\n");
 
-      ot("  sub r5,r5,#8*17 ;@ Maximum cycles divide loop can take\n");
-      ot("Divide%.4x%s\n",op,ms?"":":");
-      ot("  addcs r5,r5,#2 ;@ Count cycles for previous quotient bit\n");
-      ot("  cmp r2,r1\n");
-      ot("  adc r3,r3,r3 ;@ Double r3 and add 1 if carry set\n");
-      ot("  subcs r2,r2,r1\n");
-      ot("  teq r1,r0\n");
-      ot("  movne r1,r1,lsr #1\n");
-      ot("  bne Divide%.4x\n",op);
-      ot("\n");
-      ot(";@r3==quotient,r2==remainder\n");
-
+    if (sign)
+    {
       // sign correction
+      ot("  mov r3,r2,lsr #16\n");
       ot("  cmn r12,r12\n");
       ot("  rsbvs r3,r3,#0 ;@ negate if quotient is negative\n");
       ot("  subvs r5,r5,#2\n");
@@ -305,47 +359,22 @@ int OpMul(int op)
       ot("  subcs r5,r5,#2\n");
       ot("\n");
 
+      ot("  movs r1,r3,lsl #16 ;@ set flags based on quotient\n");
+      OpGetFlagsNZ(1);
       // signed overflow check
-      ot("  mov r1,r3,asl #16\n");
       ot("  cmp r3,r1,asr #16 ;@ signed overflow?\n");
       ot("  movne r10,#0x90000000 ;@ set overflow/negative flags\n");
       ot("  bne endofop%.4x ;@ overflow!\n",op);
       ot("\n");
-      ot("wrendofop%.4x%s\n",op,ms?"":":");
-
-      ot("  movs r1,r3,lsl #16 ;@ Clip to 16-bits\n");
-      OpGetFlagsNZ(1);
 
       ot("  mov r1,r1,lsr #16\n");
-      ot("  orr r2,r1,r2,lsl #16 ;@ Insert remainder\n");
+      ot("  orr r1,r1,r2,lsl #16 ;@ Insert remainder\n");
     }
     else
     {
-      ot(";@ Overflow?\n");
-      ot("  cmp r2,r1\n");
-      ot("  movhs r10,#0x90000000 ;@ set overflow/negative flags\n");
-      ot("  bhs endofop%.4x ;@ overflow!\n",op);
-      ot("\n");
-
-      ot(";@ Divide r2 by (r1>>16)\n");
-      ot("  mov r0,#1-(8*16/2) ;@ Maximum cycles divide loop can take\n");
-      ot("  mov r3,#15\n");
-      ot("Divide%.4x%s\n",op,ms?"":":");
-      ot("  cmp r2,r1,lsr #1\n");
-      ot("  adc r0,r0,r2,lsr #31 ;@ Save 2 cycles when subtracting, or 4 if MSB is set\n");
-      ot("  adc r2,r2,r2 ;@ Double r2 and add 1 if carry set\n");
-      ot("  subcs r2,r2,r1\n");
-      ot("  subs r3,r3,#1\n");
-      ot("  bne Divide%.4x\n",op);
-      ot("  cmp r2,r1,lsr #1\n");
-      ot("  adc r2,r2,r2 ;@ Double r2 and add 1 if carry set\n");
-      ot("  subcs r2,r2,r1\n");
-      ot("  add r5,r5,r0,lsl #1\n");
-      ot("\n");
-      ot(";@r2==remainder/quotient\n");
-
-      ot("  movs r1,r2,lsl #16 ;@ Set flags based on quotient\n");
-      OpGetFlagsNZ(1);
+      ot("  mov r1,r2,ror #16 ;@ swap quotient and remainder\n");
+      ot("  movs r2,r1,lsl #16 ;@ set flags based on quotient\n");
+      OpGetFlagsNZ(2);
     }
     ot("\n");
   }
@@ -374,12 +403,12 @@ int OpMul(int op)
     else      ZeroExtend(2,2,1);
     ot("\n");
 
-    ot("  muls r2,r0,r2\n");
-    OpGetFlagsNZ(2);
+    ot("  muls r1,r2,r0\n");
+    OpGetFlagsNZ(1);
   }
   ot("\n");
 
-  EaWrite(11, 2,rea, 2,0x0e00,earwt_shifted_up);
+  EaWrite(11, 1,rea, 2,0x0e00,earwt_shifted_up);
 
   if (type==0) ot("endofop%.4x%s\n",op,ms?"":":");
   opend_op_changes_cycles=1;

--- a/OpArith.cpp
+++ b/OpArith.cpp
@@ -254,83 +254,100 @@ int OpMul(int op)
     
     if (sign)
     {
-      ot("  mov r12,#0 ;@ r12 = 1 or 2 if the result is negative\n");
-      ot("  tst r2,r2\n");
-      ot("  orrmi r12,r12,#2\n");
+      ot("  ands r12,r2,#0x80000000 ;@ r12 = odd parity if the result is negative\n");
       ot("  submi r5,r5,#2\n");
       ot("  rsbmi r2,r2,#0 ;@ Make r2 positive\n");
       ot("\n");
       ot("  movs r0,r1,asr #16\n");
-      ot("  orrmi r12,r12,#1\n");
+      ot("  orrmi r12,r12,#0x40000000\n");
       ot("  rsbmi r0,r0,#0 ;@ Make r0 positive\n");
       ot("\n");
       ot(";@ detect the nasty 0x80000000 / -1 situation\n");
       ot("  subs r3,r2,#0x80000000\n");
       ot("  addeqs r3,r1,#0x00010000\n");
       ot("  beq wrendofop%.4x\n",op);
-    }
-    else
-    {
-      ot("  mov r0,r1,lsr #16 ;@ use only 16 bits of divisor\n");
-    }
-    ot("\n");
+      ot("\n");
 
-    ot(";@ Overflow?\n");
-    ot("  cmp r0,r2,lsr #16\n");
-    ot("  orrls r10,r10,#0x10000000 ;@ set overflow flag\n");
-    ot("  bls endofop%.4x ;@ overflow!\n",op);
-    ot("\n");
+      ot(";@ Overflow?\n");
+      ot("  cmp r0,r2,lsr #16\n");
+      ot("  movls r10,#0x90000000 ;@ set overflow/negative flags\n");
+      ot("  bls endofop%.4x ;@ overflow!\n",op);
+      ot("\n");
 
-    ot(";@ Divide r2 by r0\n");
-    ot("  mov r3,#0\n");
-    ot("  mov r1,r0\n");
-    ot("\n");
-    ot(";@ Shift up divisor till it's just less than numerator\n");
-    ot("Shift%.4x%s\n",op,ms?"":":");
-    ot("  cmp r1,r2,lsr #1\n");
-    ot("  movls r1,r1,lsl #1\n");
-    ot("  bcc Shift%.4x\n",op);
-    ot("\n");
+      ot(";@ Divide r2 by r0\n");
+      ot("  mov r3,#0\n");
+      ot("  mov r1,r0\n");
+      ot("\n");
+      ot(";@ Shift up divisor till it's just less than numerator\n");
+      ot("Shift%.4x%s\n",op,ms?"":":");
+      ot("  cmp r1,r2,lsr #1\n");
+      ot("  movls r1,r1,lsl #1\n");
+      ot("  bcc Shift%.4x\n",op);
+      ot("\n");
 
-    ot("  sub r5,r5,#8*16 ;@ Maximum cycles divide loop can take\n");
-    ot("Divide%.4x%s\n",op,ms?"":":");
-    ot("  cmp r2,r1\n");
-    ot("  adc r3,r3,r3 ;@ Double r3 and add 1 if carry set\n");
-    ot("  subcs r2,r2,r1\n");
-    ot("  addcs r5,r5,#2\n");
-    ot("  teq r1,r0\n");
-    ot("  movne r1,r1,lsr #1\n");
-    ot("  bne Divide%.4x\n",op);
-    ot("\n");
-    ot(";@r3==quotient,r2==remainder\n");
+      ot("  sub r5,r5,#8*17 ;@ Maximum cycles divide loop can take\n");
+      ot("Divide%.4x%s\n",op,ms?"":":");
+      ot("  addcs r5,r5,#2 ;@ Count cycles for previous quotient bit\n");
+      ot("  cmp r2,r1\n");
+      ot("  adc r3,r3,r3 ;@ Double r3 and add 1 if carry set\n");
+      ot("  subcs r2,r2,r1\n");
+      ot("  teq r1,r0\n");
+      ot("  movne r1,r1,lsr #1\n");
+      ot("  bne Divide%.4x\n",op);
+      ot("\n");
+      ot(";@r3==quotient,r2==remainder\n");
 
-    if (sign)
-    {
       // sign correction
-      ot("  sub r5,r5,#8\n");
-      ot("  and r1,r12,#1\n");
-      ot("  teq r1,r12,lsr #1\n");
-      ot("  rsbne r3,r3,#0 ;@ negate if quotient is negative\n");
-      ot("  subne r5,r5,#2\n");
-      ot("  tst r12,#2\n");
-      ot("  rsbne r2,r2,#0 ;@ negate the remainder if divident was negative\n");
-      ot("  subne r5,r5,#2\n");
+      ot("  cmn r12,r12\n");
+      ot("  rsbvs r3,r3,#0 ;@ negate if quotient is negative\n");
+      ot("  subvs r5,r5,#2\n");
+      ot("  rsbcs r2,r2,#0 ;@ negate the remainder if dividend was negative\n");
+      ot("  subcs r5,r5,#2\n");
       ot("\n");
 
       // signed overflow check
       ot("  mov r1,r3,asl #16\n");
       ot("  cmp r3,r1,asr #16 ;@ signed overflow?\n");
-      ot("  orrne r10,r10,#0x10000000 ;@ set overflow flag\n");
+      ot("  movne r10,#0x90000000 ;@ set overflow/negative flags\n");
       ot("  bne endofop%.4x ;@ overflow!\n",op);
       ot("\n");
       ot("wrendofop%.4x%s\n",op,ms?"":":");
+
+      ot("  movs r1,r3,lsl #16 ;@ Clip to 16-bits\n");
+      OpGetFlagsNZ(1);
+
+      ot("  mov r1,r1,lsr #16\n");
+      ot("  orr r2,r1,r2,lsl #16 ;@ Insert remainder\n");
     }
+    else
+    {
+      ot(";@ Overflow?\n");
+      ot("  cmp r2,r1\n");
+      ot("  movhs r10,#0x90000000 ;@ set overflow/negative flags\n");
+      ot("  bhs endofop%.4x ;@ overflow!\n",op);
+      ot("\n");
 
-    ot("  movs r1,r3,lsl #16 ;@ Clip to 16-bits\n");
-    OpGetFlagsNZ(1);
+      ot(";@ Divide r2 by (r1>>16)\n");
+      ot("  mov r0,#1-(8*16/2) ;@ Maximum cycles divide loop can take\n");
+      ot("  mov r3,#15\n");
+      ot("Divide%.4x%s\n",op,ms?"":":");
+      ot("  cmp r2,r1,lsr #1\n");
+      ot("  adc r0,r0,r2,lsr #31 ;@ Save 2 cycles when subtracting, or 4 if MSB is set\n");
+      ot("  adc r2,r2,r2 ;@ Double r2 and add 1 if carry set\n");
+      ot("  subcs r2,r2,r1\n");
+      ot("  subs r3,r3,#1\n");
+      ot("  bne Divide%.4x\n",op);
+      ot("  cmp r2,r1,lsr #1\n");
+      ot("  adc r2,r2,r2 ;@ Double r2 and add 1 if carry set\n");
+      ot("  subcs r2,r2,r1\n");
+      ot("  add r5,r5,r0,lsl #1\n");
+      ot("\n");
+      ot(";@r2==remainder/quotient\n");
 
-    ot("  mov r1,r1,lsr #16\n");
-    ot("  orr r1,r1,r2,lsl #16 ;@ Insert remainder\n");
+      ot("  movs r1,r2,lsl #16 ;@ Set flags based on quotient\n");
+      OpGetFlagsNZ(1);
+    }
+    ot("\n");
   }
 
   if (type==1)
@@ -363,12 +380,12 @@ int OpMul(int op)
     ot("  mov r2,r2,%s #16\n",sign?"asr":"lsr");
     ot("\n");
 
-    ot("  muls r1,r2,r0\n");
-    OpGetFlagsNZ(1);
+    ot("  muls r2,r0,r2\n");
+    OpGetFlagsNZ(2);
   }
   ot("\n");
 
-  EaWrite(11, 1,rea, 2,0x0e00,earwt_shifted_up);
+  EaWrite(11, 2,rea, 2,0x0e00,earwt_shifted_up);
 
   if (type==0) ot("endofop%.4x%s\n",op,ms?"":":");
   opend_op_changes_cycles=1;
@@ -811,30 +828,32 @@ int OpChk(int op)
   ot(";@ Get register operand into r1:\n");
   EaCalcRead(-1,1,rea,size,0x0e00,earwt_msb_dont_care);
 
-  if (size<2) ot("  mov r0,r0,asl #%d\n",size?16:24);
-
   if (size<2) ot("  movs r1,r1,asl #%d\n\n",size?16:24);
   else        ot("  adds r1,r1,#0 ;@ Define flags\n");
 
   ot(";@ get flags, including undocumented ones\n");
-  ot("  and r3,r10,#0x80000000\n");
   OpGetFlagsNZ(1);
 
   ot(";@ is reg negative?\n");
-  ot("  bmi chktrap%.4x\n",op);
+  ot("  bmi chktrapneg%.4x\n",op);
 
   ot(";@ Do arithmetic:\n");
-  ot("  cmp r1,r0\n");
+  if (size<2) ot("  cmp r1,r0,asl #%d\n",size?16:24);
+  else        ot("  cmp r1,r0\n");
   ot("  bgt chktrap%.4x\n",op);
 
-  ot(";@ old N remains\n");
-  ot("  orr r10,r10,r3\n");
   OpEnd(ea);
 
+  ot("chktrapneg%.4x%s ;@ CHK negative exception:\n",op,ms?"":":");
+  ot(";@ Delayed negative trap only if !(N||V), which is !N for a negative subtrahend\n");
+  if (size<2) ot("  rsbs r0,r1,r0,asl #%d\n",size?16:24);
+  else        ot("  cmp r0,r1\n");
+  ot("  subpl r5,r5,#2\n");
   ot("chktrap%.4x%s ;@ CHK exception:\n",op,ms?"":":");
   ot("  mov r0,#6\n");
   ot("  bl Exception\n");
   Cycles+=34-6;
+  opend_op_changes_cycles=1;
   OpEnd(ea);
 
   return 0;

--- a/OpBranch.cpp
+++ b/OpBranch.cpp
@@ -115,12 +115,14 @@ int OpLink(int op)
     ot(";@ Get An\n");
     EaCalc(11, 7, 8, 2);
     EaRead(11, 1, 8, 2, 7);
+    ot("  ldr r0,[r7,#0x3c] ;@ Get A7\n");
+    ot("  sub r0,r0,#4 ;@ A7-=4\n");
   }
-
-  ot("  ldr r0,[r7,#0x3c] ;@ Get A7\n");
-  ot("  sub r0,r0,#4 ;@ A7-=4\n");
+  else {
+    ot("  ldr r1,[r7,#0x3c] ;@ Get A7\n");
+    ot("  sub r0,r1,#4 ;@ A7-=4\n");
+  }
   ot("  mov r8,r0 ;@ abuse r8\n");
-  if(reg==7) ot("  mov r1,r0\n");
   ot("\n");
   
   ot(";@ Write An to Stack\n");

--- a/OpLogic.cpp
+++ b/OpLogic.cpp
@@ -492,7 +492,9 @@ static int EmitAsr(int op,int type,int dir,int count,int size,int usereg)
       ot("\n");
     }
 
-    if (type==0 && dir) ot("  adds r3,r0,#0 ;@ save old value for V flag calculation, also clear V\n");
+    ot("  adds r3,r0,#0 ;@ clear C and V");
+    if (type==0 && dir) ot(", also save old value for V flag calculation");
+    ot("\n");
 
     ot(";@ Shift register:\n");
     if (type==0) ot("  movs r0,r0,%s %s\n",dir?"asl":"asr",pct);
@@ -501,8 +503,7 @@ static int EmitAsr(int op,int type,int dir,int count,int size,int usereg)
     OpGetFlags(0,0);
     if (usereg) { // store X only if count is not 0
       ot("  cmp %s,#0 ;@ shifting by 0?\n",pct);
-      ot("  biceq r10,r10,#0x20000000 ;@ if so, clear carry\n");
-      ot("  strne r10,[r7,#0x4c] ;@ else Save X bit\n");
+      ot("  strne r10,[r7,#0x4c] ;@ if not, Save X bit\n");
     } else {
       // count will never be 0 if we use immediate
       ot("  str r10,[r7,#0x4c] ;@ Save X bit\n");
@@ -520,11 +521,7 @@ static int EmitAsr(int op,int type,int dir,int count,int size,int usereg)
 
     if (type==0 && dir) {
       ot(";@ calculate V flag (set if sign bit changes at anytime):\n");
-      ot("  mov r1,#0x80000000\n");
-      ot("  ands r3,r3,r1,asr %s\n", pct);
-      ot("  cmpne r3,r1,asr %s\n", pct);
-      ot("  eoreq r1,r0,r3\n"); // above check doesn't catch (-1)<<(32+), so we need this
-      ot("  tsteq r1,#0x80000000\n");
+      ot("  cmp r3,r0,asr %s\n", pct);
       ot("  orrne r10,r10,#0x10000000\n");
       ot("\n");
     }

--- a/OpMove.cpp
+++ b/OpMove.cpp
@@ -473,7 +473,7 @@ int OpMovem(int op)
   }
 
   ot("NoRegs%.4x%s\n",op, ms?"":":");
-  ot("  ldr r4,[r7,#0x40]\n");
+  ot("  ldr r4,[r7,#0x40]\n"); pc_in_reg=1;
   ot("  ldr r6,[r7,#0x54] ;@ restore Opcode Jump table\n");
   ot("\n");
 

--- a/app.h
+++ b/app.h
@@ -20,6 +20,18 @@
 #endif
 #include CONFIG_FILE
 
+// Enforce ARM architecture hierarchy even if a custom config file doesn't
+#ifndef HAVE_ARMv6
+#define HAVE_ARMv6 0
+#elif HAVE_ARMv6
+#undef HAVE_ARMv5
+#define HAVE_ARMv5 1
+#endif
+
+#ifndef HAVE_ARMv5
+#define HAVE_ARMv5 0
+#endif
+
 // Disa.c
 #include "Disa/Disa.h"
 

--- a/app.h
+++ b/app.h
@@ -66,6 +66,8 @@ extern const char * const Narm[4]; // Normal ARM Extensions for operand sizes 0,
 extern const char * const Sarm[4]; // Sign-extend ARM Extensions for operand sizes 0,1,2
 extern int  Cycles;   // Current cycles for opcode
 extern int  pc_dirty; // something changed PC during processing
+extern int  pc_in_reg; // PC is currently held in r4
+extern int  flags_in_reg; // flags are currently held in r10
 extern int  arm_op_count; // for stats
 void ot(const char *format, ...)
 #ifdef __GNUC__

--- a/config.h
+++ b/config.h
@@ -10,9 +10,14 @@
  * If you want Cyclone to make use of newer ARM instructions, enable the
  * options(s) below. You can also override this using make argument:
  *   make HAVE_ARMv6=1
+ * Note: The highest enabled architecture version implicitly enables
+ * all lower versions.
  */
 #ifndef HAVE_ARMv6
 #define HAVE_ARMv6                  0
+#endif
+#ifndef HAVE_ARMv5
+#define HAVE_ARMv5                  0
 #endif
 
 /*
@@ -37,6 +42,12 @@
  * CycloneRun(), or else it will crash.
  */
 #define COMPRESS_JUMPTABLE          1
+
+/*
+ * If enabled, inlines unrolled division in each DIVU/DIVS opcode handler.
+ * Saves 2 branches per divide, but costs ~1.3k instructions.
+ */
+#define INLINE_UNROLLED_DIV         0
 
 /*
  * Address mask for memory hadlers. The bits set will be masked out of address

--- a/tests/SingleStepTests/Makefile
+++ b/tests/SingleStepTests/Makefile
@@ -1,0 +1,37 @@
+ifeq ($(HAVE_ARMv6),1)
+ARCH = armv6
+CPU = arm11mpcore
+else
+ARCH = armv4t
+CPU = arm946 # arm920 not supported in qemu...
+endif
+
+AS = arm-linux-gnueabi-as
+ASFLAGS += -march=$(ARCH) -mfloat-abi=soft
+CXX = arm-linux-gnueabi-g++
+CFLAGS += -march=$(ARCH) -mfloat-abi=soft -Wall -ggdb -O2
+CXXFLAGS += $(CFLAGS)
+LDFLAGS += -static
+EMU = qemu-arm -cpu $(CPU)
+
+OBJS = tester.o Cyclone.o
+
+.PHONY: all test clean cyclone
+
+all: cyclone tester
+
+test: cyclone tester
+	$(EMU) tester
+
+clean:
+	$(RM) $(OBJS) tester
+	$(MAKE) -C ../.. clean
+
+cyclone:
+	$(MAKE) -C ../..
+
+tester: $(OBJS)
+	$(CXX) -o $@ $^ $(LDFLAGS)
+
+Cyclone.o: ../../Cyclone.s
+	$(AS) $(ASFLAGS) -o $@ ../../Cyclone.s

--- a/tests/SingleStepTests/Makefile
+++ b/tests/SingleStepTests/Makefile
@@ -2,8 +2,13 @@ ifeq ($(HAVE_ARMv6),1)
 ARCH = armv6
 CPU = arm11mpcore
 else
+ifeq ($(HAVE_ARMv5),1)
+ARCH = armv5t
+CPU = arm946
+else
 ARCH = armv4t
 CPU = arm946 # arm920 not supported in qemu...
+endif
 endif
 
 AS = arm-linux-gnueabi-as

--- a/tests/SingleStepTests/tester.cpp
+++ b/tests/SingleStepTests/tester.cpp
@@ -1,0 +1,466 @@
+#include "../../Cyclone.h"
+
+#include <cinttypes>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <utility>
+
+enum class TestStatus
+{
+    Passed,
+    Failed,
+    Skipped,
+    Warning,
+};
+
+struct TestStats
+{
+    unsigned passes = 0;
+    unsigned failures = 0;
+    unsigned skips = 0;
+    unsigned warnings = 0;
+};
+
+static constexpr unsigned int MEM_SIZE = 0x1000000;
+static constexpr unsigned int DIRTY_PAGE_SIZE = 0x1000;
+
+static struct Cyclone cpu;
+static struct Cyclone final_cpu;
+
+static uint8_t memory[MEM_SIZE];
+static uint8_t final_memory[MEM_SIZE];
+static uint8_t memory_dirty[MEM_SIZE / DIRTY_PAGE_SIZE];
+
+// memhandlers externally defined with the default prefix in case MEMHANDLERS_DIRECT_PREFIX is used
+extern "C" unsigned int cyclone_checkpc(unsigned int pc)
+{
+    pc -= cpu.membase;
+    unsigned int pc_addr = (unsigned int)&memory[pc & (MEM_SIZE - 2)];
+    // preserve the upper 8 bits of PC in the membase
+    cpu.membase = pc_addr - pc;
+    return pc_addr;
+}
+
+extern "C" unsigned int cyclone_read8(unsigned int a)
+{
+    a &= MEM_SIZE - 1;
+    return memory[a ^ 1];
+}
+
+extern "C" unsigned int cyclone_read16(unsigned int a)
+{
+    a &= MEM_SIZE - 2;
+    return *(const uint16_t*)(memory + a);
+}
+
+extern "C" unsigned int cyclone_read32(unsigned int a)
+{
+    unsigned int d = cyclone_read16(a) << 16;
+    return d | cyclone_read16(a + 2);
+}
+
+extern "C" void cyclone_write8(unsigned int a, unsigned char d)
+{
+    a &= MEM_SIZE - 1;
+    memory[a ^ 1] = d;
+    memory_dirty[a / DIRTY_PAGE_SIZE] = 1;
+}
+
+extern "C" void cyclone_write16(unsigned int a, unsigned short d)
+{
+    a &= MEM_SIZE - 2;
+    *(uint16_t*)(memory + a) = d;
+    memory_dirty[a / DIRTY_PAGE_SIZE] = 1;
+}
+
+extern "C" void cyclone_write32(unsigned int a, unsigned int d)
+{
+    cyclone_write16(a, (unsigned short)(d >> 16));
+    cyclone_write16(a + 2, (unsigned short)d);
+}
+
+extern "C" unsigned int cyclone_fetch8(unsigned int a)
+{
+    return cyclone_read8(a);
+}
+
+extern "C" unsigned int cyclone_fetch16(unsigned int a)
+{
+    return cyclone_read16(a);
+}
+
+extern "C" unsigned int cyclone_fetch32(unsigned int a)
+{
+    return cyclone_read32(a);
+}
+
+static bool read_failure()
+{
+    puts("Failed to read from test file");
+    return false;
+}
+
+static bool read8(FILE* test_file, uint8_t& value)
+{
+    if (fread(&value, sizeof(value), 1, test_file) == 1) return true;
+
+    return read_failure();
+}
+
+static bool read16(FILE* test_file, uint16_t& value)
+{
+    if (fread(&value, sizeof(value), 1, test_file) == 1) return true;
+
+    return read_failure();
+}
+
+static bool read32(FILE* test_file, uint32_t& value)
+{
+    if (fread(&value, sizeof(value), 1, test_file) == 1) return true;
+
+    return read_failure();
+}
+
+static bool read_name(FILE* test_file, std::string& name)
+{
+    uint32_t num_bytes, name_magic, name_len;
+    if (!read32(test_file, num_bytes)) return false;
+    if (!read32(test_file, name_magic)) return false;
+    if (name_magic != UINT32_C(0x89ABCDEF))
+    {
+        puts("Test name magic is incorrect!");
+        return false;
+    }
+
+    if (!read32(test_file, name_len)) return false;
+    name.resize(name_len);
+
+    if (fread(name.data(), name_len, 1, test_file) == 1) return true;
+
+    return read_failure();
+}
+
+static bool read_transactions(FILE* test_file, uint32_t& cycles, bool& has_error)
+{
+    has_error = false;
+
+    uint32_t num_bytes, transactions_magic, num_transactions;
+    if (!read32(test_file, num_bytes)) return false;
+    if (!read32(test_file, transactions_magic)) return false;
+    if (transactions_magic != UINT32_C(0x456789AB))
+    {
+        puts("Test transactions magic is incorrect!");
+        return false;
+    }
+
+    if (!read32(test_file, cycles)) return false;
+    if (!read32(test_file, num_transactions)) return false;
+
+    while (num_transactions--)
+    {
+        uint8_t tw;
+        uint32_t tcyc;
+        if (!read8(test_file, tw)) return false;
+        if (!read32(test_file, tcyc)) return false;
+        if (tw == 0) continue;
+
+        uint32_t fc, addr_bus, data_bus, UDS, LDS;
+        if (!read32(test_file, fc)) return false;
+        if (!read32(test_file, addr_bus)) return false;
+        if (!read32(test_file, data_bus)) return false;
+        if (!read32(test_file, UDS)) return false;
+        if (!read32(test_file, LDS)) return false;
+
+        if (tw >= 4) has_error = true;
+    }
+
+    return true;
+}
+
+static bool read_state(FILE* test_file, struct Cyclone& state, uint8_t* mem)
+{
+    uint32_t num_bytes, state_magic;
+    if (!read32(test_file, num_bytes)) return false;
+    if (!read32(test_file, state_magic)) return false;
+    if (state_magic != UINT32_C(0x01234567))
+    {
+        puts("Test state magic is incorrect!");
+        return false;
+    }
+
+    uint32_t reg;
+    for (size_t i = 0; i < 8; i++)
+    {
+        if (!read32(test_file, reg)) return false;
+        state.d[i] = reg;
+    }
+
+    for (size_t i = 0; i < 8; i++)
+    {
+        if (!read32(test_file, reg)) return false;
+        state.a[i] = reg;
+    }
+
+    if (!read32(test_file, reg)) return false;
+    state.osp = reg;
+
+    if (!read32(test_file, reg)) return false;
+    CycloneSetSr(&state, reg);
+    // Swap USP and SSP if applicable
+    if (reg & 0x2000) std::swap(state.a[7], state.osp);
+
+    if (!read32(test_file, reg)) return false;
+    // Remove prefetch adjustment from PC
+    state.pc = reg - 4;
+    state.membase = 0;
+
+    // Prefetch values, ignore
+    if (!read32(test_file, reg)) return false;
+    if (!read32(test_file, reg)) return false;
+
+    uint32_t mem_count;
+    if (!read32(test_file, mem_count)) return false;
+
+    while (mem_count--)
+    {
+        uint32_t a;
+        uint16_t d;
+        if (!read32(test_file, a)) return false;
+        if (!read16(test_file, d)) return false;
+        a &= MEM_SIZE - 2;
+        *(uint16_t*)(mem + a) = d;
+        memory_dirty[a / DIRTY_PAGE_SIZE] = 1;
+    }
+    return true;
+}
+
+static void clean_memory()
+{
+    for (size_t i = 0; i < MEM_SIZE / DIRTY_PAGE_SIZE; i++)
+    {
+        if (memory_dirty[i])
+        {
+            memset(&memory[i * DIRTY_PAGE_SIZE], 0, DIRTY_PAGE_SIZE);
+            memset(&final_memory[i * DIRTY_PAGE_SIZE], 0, DIRTY_PAGE_SIZE);
+            memory_dirty[i] = 0;
+        }
+    }
+}
+
+static uint32_t state_get_pc(const struct Cyclone& state)
+{
+    uint32_t pc = state.pc - state.membase;
+    // Adjust for stopped state, expects PC to point at stop instruction for some reason
+    if (state.state_flags & 1)
+    {
+        pc -= 4;
+    }
+    return pc;
+}
+
+static bool states_equal()
+{
+    if (memcmp(&cpu.d, &final_cpu.d, sizeof(cpu.d)) != 0) return false;
+    if (memcmp(&cpu.a, &final_cpu.a, sizeof(cpu.a)) != 0) return false;
+    if (cpu.osp != final_cpu.osp) return false;
+    if (CycloneGetSr(&cpu) != CycloneGetSr(&final_cpu)) return false;
+    if (state_get_pc(cpu) != state_get_pc(final_cpu)) return false;
+
+    for (size_t i = 0; i < MEM_SIZE / DIRTY_PAGE_SIZE; i++)
+    {
+        if (memory_dirty[i])
+        {
+            if (memcmp(&memory[i * DIRTY_PAGE_SIZE],
+                       &final_memory[i * DIRTY_PAGE_SIZE],
+                       DIRTY_PAGE_SIZE) != 0)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+static void print_state(struct Cyclone& state, const uint8_t* mem)
+{
+    unsigned int sr = CycloneGetSr(&state);
+    bool sys = sr & 0x2000;
+
+    for (size_t i = 0; i < 8; i++)
+    {
+        printf("d%c=%08x\n", '0'+i, state.d[i]);
+    }
+    for (size_t i = 0; i < 7; i++)
+    {
+        printf("a%c=%08x\n", '0'+i, state.a[i]);
+    }
+    printf("usp=%08x\n", !sys ? state.a[7] : state.osp);
+    printf("ssp=%08x\n", sys ? state.a[7] : state.osp);
+    printf("sr=%08x\n", sr);
+    printf("pc=%08x\n", state_get_pc(state));
+
+    for (uint32_t addr = 0; addr < MEM_SIZE; addr += 2)
+    {
+        uint16_t data = *(const uint16_t*)(mem + addr);
+        if (data)
+        {
+            printf("mem[%06" PRIx32 "]=%04" PRIx16 "\n", addr, data);
+        }
+    }
+}
+
+static bool run_test(FILE* test_file, TestStatus& status, bool& show_failure)
+{
+    status = TestStatus::Passed;
+
+    uint32_t num_bytes, test_magic;
+    if (!read32(test_file, num_bytes)) return false;
+    if (!read32(test_file, test_magic)) return false;
+    if (test_magic != UINT32_C(0xABC12367))
+    {
+        puts("Test magic is incorrect!");
+        return false;
+    }
+
+    std::string test_name;
+    if (!read_name(test_file, test_name)) return false;
+    clean_memory();
+    if (!read_state(test_file, cpu, memory)) return false;
+    if (!read_state(test_file, final_cpu, final_memory)) return false;
+    uint32_t cycles;
+    bool has_error;
+    if (!read_transactions(test_file, cycles, has_error)) return false;
+
+    if (has_error)
+    {
+        status = TestStatus::Skipped;
+        return true;
+    }
+
+    cpu.state_flags = 0;
+    cpu.cycles = 0;
+    cpu.pc = cpu.checkpc(cpu.pc);
+    CycloneRun(&cpu);
+
+    if ((uint32_t)-cpu.cycles != cycles)
+    {
+        status = TestStatus::Warning;
+        printf("Warning: %s expected %" PRIu32 " cycles, got %d\n",
+            test_name.c_str(), cycles, -cpu.cycles);
+    }
+
+    if (!states_equal())
+    {
+        status = TestStatus::Failed;
+        if (show_failure)
+        {
+            show_failure = false;
+            printf("Test failed: %s\n", test_name.c_str());
+            printf("Expected state:\n");
+            print_state(final_cpu, final_memory);
+            printf("Actual state:\n");
+            print_state(cpu, memory);
+        }
+        return true;
+    }
+
+    return true;
+}
+
+static bool run_tests(FILE* test_file, TestStats& total_stats)
+{
+    uint32_t file_magic, num_tests;
+    if (!read32(test_file, file_magic)) return false;
+    if (file_magic != UINT32_C(0x1A3F5D71))
+    {
+        puts("Test file magic is incorrect!");
+        return false;
+    }
+
+    if (!read32(test_file, num_tests)) return false;
+    printf("Running %" PRIu32 " tests\n", num_tests);
+
+    struct TestStats stats;
+    bool show_failure = true;
+    bool result = true;
+    for (; num_tests; num_tests--)
+    {
+        enum TestStatus status;
+        result = run_test(test_file, status, show_failure);
+        if (!result) break;
+        switch (status)
+        {
+        case TestStatus::Passed:
+            stats.passes++;
+            break;
+        case TestStatus::Failed:
+            stats.failures++;
+            break;
+        case TestStatus::Skipped:
+            stats.skips++;
+            break;
+        case TestStatus::Warning:
+            stats.warnings++;
+            stats.passes++;
+            break;
+	}
+    }
+
+    stats.skips += num_tests;
+    printf("%u passed, %u skipped, %u failed, %u warnings\n",
+           stats.passes, stats.skips, stats.failures, stats.warnings);
+
+    total_stats.passes += stats.passes;
+    total_stats.skips += stats.skips;
+    total_stats.failures += stats.failures;
+    total_stats.warnings += stats.warnings;
+
+    return result;
+}
+
+int main()
+{
+    cpu.checkpc = cyclone_checkpc;
+    cpu.read8 = cyclone_read8;
+    cpu.read16 = cyclone_read16;
+    cpu.read32 = cyclone_read32;
+    cpu.write8 = cyclone_write8;
+    cpu.write16 = cyclone_write16;
+    cpu.write32 = cyclone_write32;
+    cpu.fetch8 = cyclone_fetch8;
+    cpu.fetch16 = cyclone_fetch16;
+    cpu.fetch32 = cyclone_fetch32;
+
+    CycloneInit();
+    CycloneReset(&cpu);
+
+    TestStats stats;
+    unsigned errored = 0;
+    for (const auto& dir_entry : std::filesystem::directory_iterator("m68000/v1"))
+    {
+        const char* test_path = dir_entry.path().c_str();
+        printf("Running tests from %s\n", test_path);
+        FILE* test_file = fopen(test_path, "rb");
+        if (!test_file)
+        {
+            perror("Failed to open test file");
+            return EXIT_FAILURE;
+        }
+        if (!run_tests(test_file, stats))
+        {
+            errored++;
+        }
+    }
+    puts("Test summary:");
+    if (errored != 0)
+    {
+        printf("%u test files had parsing errors\n", errored);
+    }
+
+    printf("%u passed, %u skipped, %u failed, %u warnings\n",
+           stats.passes, stats.skips, stats.failures, stats.warnings);
+
+    return EXIT_SUCCESS;
+}

--- a/tests/SingleStepTests/tester.cpp
+++ b/tests/SingleStepTests/tester.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
+#include <random>
 #include <string>
 #include <utility>
 
@@ -420,6 +421,131 @@ static bool run_tests(FILE* test_file, TestStats& total_stats)
     return result;
 }
 
+class RandomSeedSeq
+{
+public:
+    using result_type = std::random_device::result_type;
+
+    template<typename Iter>
+    void generate(Iter begin, Iter end)
+    {
+        while (begin != end) *begin++ = device();
+    }
+
+private:
+    std::random_device device;
+};
+
+// Exercise more DIVU/DIVS code paths not covered by SST's uniform random distribution
+// This helps verify the division implementation's iteration-skipping logic is correct
+bool div_iter_tests()
+{
+    unsigned int sr;
+    bool success = true;
+    RandomSeedSeq seed;
+    std::mt19937 g{seed};
+    std::uniform_int_distribution<uint32_t> dividend_d;
+    std::uniform_int_distribution<uint16_t> divisor_d;
+    std::uniform_int_distribution<int> dividend_shift_d(-1, 31);
+    std::uniform_int_distribution<int> divisor_shift_d(-1, 15);
+
+    clean_memory();
+    cyclone_write16(0, 0x80c1); // divu.w d1, d0
+    cyclone_write16(2, 0x81c1); // divs.w d1, d0
+
+    for (int i = 0; i < 10000000; i++)
+    {
+        uint32_t dividend = dividend_d(g);
+        uint16_t divisor = divisor_d(g);
+        int dividend_shift = dividend_shift_d(g);
+        int divisor_shift = dividend_shift_d(g);
+
+        int32_t dividend_s = dividend_shift < 0 ? INT32_MIN : (int32_t)dividend >> dividend_shift;
+        int16_t divisor_s = divisor_shift < 0 ? INT16_MIN : (int16_t)divisor >> divisor_shift;
+        dividend = dividend_shift < 0 ? UINT32_MAX : dividend >> dividend_shift;
+        divisor = divisor_shift < 0 ? UINT16_MAX : divisor >> divisor_shift;
+
+        cpu.state_flags = 0;
+        cpu.cycles = 0;
+        cpu.membase = 0;
+        cpu.pc = cpu.checkpc(0);
+        CycloneSetSr(&cpu, 0);
+        cpu.d[0] = dividend;
+        cpu.d[1] = divisor;
+        cpu.a[7] = cpu.osp = 0;
+        CycloneRun(&cpu);
+        sr = CycloneGetSr(&cpu);
+
+        success = !(sr & 0x2000);
+        if (divisor != 0)
+        {
+            uint32_t quotient = dividend / divisor;
+            uint32_t remainder = dividend % divisor;
+            if (quotient != (uint16_t)quotient)
+            {
+                success &= !!(sr & 0x2);
+                success &= (cpu.d[0] == dividend);
+            }
+            else
+            {
+                success &= !(sr & 0x2);
+                success &= (cpu.d[0] == ((remainder << 16) | quotient));
+            }
+        }
+        else
+        {
+            success = !success;
+        }
+        if (!success)
+        {
+            printf("DIVU(%08x,%04x) failed:\n", dividend, divisor);
+            print_state(cpu, memory);
+            break;
+        }
+
+        cpu.state_flags = 0;
+        cpu.cycles = 0;
+        cpu.membase = 0;
+        cpu.pc = cpu.checkpc(2);
+        CycloneSetSr(&cpu, 0);
+        cpu.d[0] = dividend_s;
+        cpu.d[1] = divisor_s;
+        cpu.a[7] = cpu.osp = 0;
+        CycloneRun(&cpu);
+        sr = CycloneGetSr(&cpu);
+
+        success = !(sr & 0x2000);
+        if (divisor_s != 0)
+        {
+            // divide as 64-bit to avoid overflow UB
+            int64_t quotient = (int64_t)dividend_s / divisor_s;
+            int32_t remainder = (int64_t)dividend_s % divisor_s;
+            if (quotient != (int16_t)quotient)
+            {
+                success &= !!(sr & 0x2);
+                success &= (cpu.d[0] == (uint32_t)dividend_s);
+            }
+            else
+            {
+                success &= !(sr & 0x2);
+                success &= (cpu.d[0] == (((uint32_t)remainder << 16) | (uint16_t)quotient));
+            }
+        }
+        else
+        {
+            success = !success;
+        }
+        if (!success)
+        {
+            printf("DIVS(%08x,%04x) failed:\n", (unsigned)dividend_s, (unsigned)(divisor_s & 0xffff));
+            print_state(cpu, memory);
+            break;
+        }
+    }
+
+    return success;
+}
+
 int main()
 {
     cpu.checkpc = cyclone_checkpc;
@@ -461,6 +587,12 @@ int main()
 
     printf("%u passed, %u skipped, %u failed, %u warnings\n",
            stats.passes, stats.skips, stats.failures, stats.warnings);
+
+    puts("Running DIV* iter tests...");
+    if (div_iter_tests())
+    {
+        puts("DIV* iter tests passed");
+    }
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I've been considering doing some work in a fork for supporting ARM M-profile (i.e. Thumb-2 only platforms), but first I wanted to get some automated tests running against known good data. The SingleStepTests cases I'm introducing were generated from MAME's microcode-based emulator core, and exposed a few minor accuracy issues in Cyclone (primarily originating from Musashi, it seems) that I thought I should fix and PR back in.

Note: I made the tester skip tests with address errors, which had some additional accuracy issues, but those could possibly be *addressed* in a future PR. ;)

Before fixes: `259749 passed, 55606 skipped, 2145 failed, 1224 warnings`
After fixes: `261894 passed, 55606 skipped, 0 failed, 0 warnings`

If you don't want the SingleStepTests as a submodule in your repo, I can certainly remove the tester from the PR, but I found them quite useful and I made the tester really easy to cross-compile and run in qemu with `make test`.

The behavioral differences are as follows, which I independently verified on the M68000 in my TI-89 Titanium:
* `CHK`: The flags are always set based on the value of the checked data register. The original N flag is not preserved.
* `DIV*`: The flags in overflow cases are set to N=1, Z=0, V=1, C=0. Additionally, the SSTs didn't expose this, but I had a suspicion and verified that there is no special case for -0x80000000 / -1 where the destination register is set to 0. It's simply a normal overflow case where the destination register is preserved. (I suspect the special case came about because Musashi was using hardware division and wanted to avoid exceptions or UB on the host system, but I have no idea why it sets the destination and flags to 0.)
* `LINK`: When A7 is used as the link register, its value *prior* to decrementing A7 is stored to memory.

Changes in cycle timing are as follows:
* `CHK`: This instruction performs the comparison against the upper bound prior to the sign check, which means if it fails due to the sign check and *not* due to the comparison, it takes 2 additional cycles. The annoying part is that the upper bound comparison is done by subtracting the data register from the bound, and then checking `N | V` (yes, not `N ^ V`). Fortunately, I was able to insert this check in the cold path where it's already known that the exception will be thrown. We only need to check this condition for the cycle difference when the data register is negative, and in that case `N | V` simplifies to just `N`. Convenient!
* `DIVS`: The cycle counting for this was already mostly correct, but it was missing the detail that the lowest bit of the quotient doesn't affect the length of the instruction.
* `DIVU`: In addition to the same problem as for `DIVS`, the algorithm didn't account for the saved cycles when the shifted remainder has a carry-out (which is understandable due to the potential performance loss). To fix this, I rewrote the division algorithm to do correct cycle counting for cheap. More on this below.

Optimizations:
* `MUL*`: This was fairly minor, but I realized that `MULS` was doing a 17-bit popcount where the most significant bit was always 0, so I changed it to a 16-bit popcount. Additionally, I realized the constant masks for the popcount could be generated from each other in fewer instructions than generating them independently.
* `DIV*`: I rewrote the inner loop entirely to favor a fully unrolled implementation, but still preserving the old behavior of skipping iterations based on the magnitude of the quotient. I also added a `HAVE_ARMv5` option to allow usage of `CLZ` for faster iteration-skipping logic. The inner loop body has been reduced to 3 instructions per quotient bit (2 for the division logic, and 1 for the 3-way cycle counting). Based on the size of the unrolled loop, I decided to out-of-line the implementation by default, which I feel is reasonable because even out-of-line, the number of branches has been reduced to 3 from the previous 0-30 branches across two loops. However, in the Cyclone spirit of "inline literally everything", I added a config option to allow inlining it anyway (at a cost of 1.3k-ish instructions).

I also found and fixed a bug where the `sprintf()` for the name of a memory handler was in a bad position that messed with the scope of an `else` block when `EMULATE_ADDRESS_ERRORS_IO` was enabled. That caused redundant code generation, calculating LR (and R0, if applicable) twice when calling a word/long memory handler. And also, since the `sprintf()` was in the `else` block, the name of the memory handler in the ASM comment was also corrupted (which is what made me notice this in the first place).